### PR TITLE
fix(security): persistent JWT keys, PKCE, env-var secrets, CORS from config

### DIFF
--- a/src/main/java/com/example/config/AuthorizationServerConfig.java
+++ b/src/main/java/com/example/config/AuthorizationServerConfig.java
@@ -5,6 +5,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -16,37 +17,48 @@ import org.springframework.security.oauth2.server.authorization.token.OAuth2Toke
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
 import java.util.UUID;
 
 @Configuration
 public class AuthorizationServerConfig {
-    
+
+    @Value("${jwt.key-path:keys/jwt}")
+    private String keyPath;
+
     @Bean
     public SecurityFilterChain authServerSecurityFilterChain(HttpSecurity http) throws Exception {
         OAuth2AuthorizationServerConfiguration.applyDefaultSecurity(http);
-        
+
         http.getConfigurer(OAuth2AuthorizationServerConfigurer.class)
                 .oidc(oidc -> {
                         // Enable OpenID Connect 1.0 with default configuration
                 });
-        
+
         http.exceptionHandling(exceptions -> exceptions
                 .defaultAuthenticationEntryPointFor(
                         new LoginUrlAuthenticationEntryPoint("/login"),
                         request -> request.getRequestURI().startsWith("/oauth2/")
                 )
         );
-        
+
         return http.build();
     }
 
     @Bean
     public JWKSource<SecurityContext> jwkSource() {
-        KeyPair keyPair = generateRsaKey();
+        KeyPair keyPair = loadOrGenerateRsaKey();
         RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
         RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
         RSAKey rsaKey = new RSAKey.Builder(publicKey)
@@ -69,21 +81,87 @@ public class AuthorizationServerConfig {
                 // Add custom claims to JWT
                 context.getClaims().claim("iss_custom", "OAuth2 Authorization Server");
                 context.getClaims().claim("server_version", "1.0.0");
-                
+
                 // Add user authorities/roles to JWT if available
                 if (context.getPrincipal() != null && context.getPrincipal().getAuthorities() != null) {
-                    context.getClaims().claim("authorities", 
+                    context.getClaims().claim("authorities",
                         context.getPrincipal().getAuthorities().stream()
                             .map(authority -> authority.getAuthority())
                             .toList());
                 }
-                
+
                 // Add client information
                 if (context.getRegisteredClient() != null) {
                     context.getClaims().claim("client_name", context.getRegisteredClient().getClientId());
                 }
             }
         };
+    }
+
+    private KeyPair loadOrGenerateRsaKey() {
+        File privateKeyFile = new File(keyPath + ".private.pem");
+        File publicKeyFile = new File(keyPath + ".public.pem");
+
+        if (privateKeyFile.exists() && publicKeyFile.exists()) {
+            try {
+                return loadRsaKey(privateKeyFile, publicKeyFile);
+            } catch (Exception ex) {
+                throw new IllegalStateException("Failed to load RSA key pair from " + keyPath, ex);
+            }
+        }
+
+        KeyPair keyPair = generateRsaKey();
+        try {
+            saveRsaKey(keyPair, privateKeyFile, publicKeyFile);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to save RSA key pair to " + keyPath, ex);
+        }
+        return keyPair;
+    }
+
+    private KeyPair loadRsaKey(File privateKeyFile, File publicKeyFile) throws Exception {
+        String privateKeyPem = readFile(privateKeyFile)
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+        String publicKeyPem = readFile(publicKeyFile)
+                .replace("-----BEGIN PUBLIC KEY-----", "")
+                .replace("-----END PUBLIC KEY-----", "")
+                .replaceAll("\\s", "");
+
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        RSAPrivateKey privateKey = (RSAPrivateKey) keyFactory.generatePrivate(
+                new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKeyPem)));
+        RSAPublicKey publicKey = (RSAPublicKey) keyFactory.generatePublic(
+                new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyPem)));
+
+        return new KeyPair(publicKey, privateKey);
+    }
+
+    private void saveRsaKey(KeyPair keyPair, File privateKeyFile, File publicKeyFile) throws IOException {
+        privateKeyFile.getParentFile().mkdirs();
+        try (FileWriter writer = new FileWriter(privateKeyFile)) {
+            writer.write("-----BEGIN PRIVATE KEY-----\n");
+            writer.write(Base64.getMimeEncoder(64, new byte[]{'\n'}).encodeToString(keyPair.getPrivate().getEncoded()));
+            writer.write("\n-----END PRIVATE KEY-----\n");
+        }
+        try (FileWriter writer = new FileWriter(publicKeyFile)) {
+            writer.write("-----BEGIN PUBLIC KEY-----\n");
+            writer.write(Base64.getMimeEncoder(64, new byte[]{'\n'}).encodeToString(keyPair.getPublic().getEncoded()));
+            writer.write("\n-----END PUBLIC KEY-----\n");
+        }
+    }
+
+    private String readFile(File file) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        try (FileReader reader = new FileReader(file)) {
+            char[] buf = new char[1024];
+            int n;
+            while ((n = reader.read(buf)) != -1) {
+                sb.append(buf, 0, n);
+            }
+        }
+        return sb.toString();
     }
 
     private KeyPair generateRsaKey() {

--- a/src/main/java/com/example/config/DefaultSecurityConfig.java
+++ b/src/main/java/com/example/config/DefaultSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -14,6 +15,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -22,6 +24,9 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Configuration
 @EnableWebSecurity
 public class DefaultSecurityConfig {
+
+    @Value("${cors.allowed-origins:}")
+    private String corsAllowedOrigins;
 
     @Bean
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -46,24 +51,29 @@ public class DefaultSecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        
-        // Allow specific origins in development, configure properly for production
-        configuration.setAllowedOriginPatterns(List.of(
+
+        List<String> origins = new ArrayList<>(List.of(
             "http://localhost:*",
-            "https://localhost:*",
-            "https://*.yourdomain.com" // Replace with your production domain
+            "https://localhost:*"
         ));
-        
+
+        if (corsAllowedOrigins != null && !corsAllowedOrigins.isBlank()) {
+            for (String origin : corsAllowedOrigins.split(",")) {
+                String trimmed = origin.trim();
+                if (!trimmed.isEmpty()) {
+                    origins.add(trimmed);
+                }
+            }
+        }
+
+        configuration.setAllowedOriginPatterns(origins);
         configuration.setAllowedMethods(Arrays.asList(
             "GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"
         ));
-        
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
-        
-        // Cache preflight response for 1 hour
         configuration.setMaxAge(3600L);
-        
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/src/main/java/com/example/config/RegisteredClientConfig.java
+++ b/src/main/java/com/example/config/RegisteredClientConfig.java
@@ -1,5 +1,6 @@
 package com.example.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -17,13 +18,18 @@ import java.util.UUID;
 
 @Configuration
 public class RegisteredClientConfig {
-    
+
+    @Value("${oauth2.client.secret:secret}")
+    private String clientSecret;
+
+    @Value("${oauth2.extra-redirect-uri:}")
+    private String extraRedirectUri;
+
     @Bean
     public RegisteredClientRepository registeredClientRepository(PasswordEncoder passwordEncoder) {
-        // Development/Test client
-        RegisteredClient testClient = RegisteredClient.withId(UUID.randomUUID().toString())
+        RegisteredClient.Builder builder = RegisteredClient.withId(UUID.randomUUID().toString())
                 .clientId("test-client")
-                .clientSecret(passwordEncoder.encode("secret"))
+                .clientSecret(passwordEncoder.encode(clientSecret))
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
@@ -31,46 +37,24 @@ public class RegisteredClientConfig {
                 .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
                 .redirectUri("http://localhost:9000/login/oauth2/code/test-client")
                 .redirectUri("http://localhost:9000/authorized")
-                .redirectUri("https://oauth.pstmn.io/v1/callback") // For Postman testing
                 .scope(OidcScopes.OPENID)
                 .scope(OidcScopes.PROFILE)
                 .scope("read")
                 .scope("write")
                 .clientSettings(ClientSettings.builder()
                         .requireAuthorizationConsent(true)
-                        .requireProofKey(false) // Disabled for easier testing; enable in production
+                        .requireProofKey(true)
                         .build())
                 .tokenSettings(TokenSettings.builder()
                         .accessTokenTimeToLive(Duration.ofHours(1))
                         .refreshTokenTimeToLive(Duration.ofDays(30))
-                        .reuseRefreshTokens(false) // Better security
-                        .build())
-                .build();
-
-        // Production client example (commented out for development)
-        /*
-        RegisteredClient productionClient = RegisteredClient.withId(UUID.randomUUID().toString())
-                .clientId("production-client")
-                .clientSecret(passwordEncoder.encode("${OAUTH2_CLIENT_SECRET:production-secret}"))
-                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-                .redirectUri("https://your-app.com/login/oauth2/code/production-client")
-                .scope(OidcScopes.OPENID)
-                .scope(OidcScopes.PROFILE)
-                .scope("read")
-                .clientSettings(ClientSettings.builder()
-                        .requireAuthorizationConsent(true)
-                        .requireProofKey(true) // Enable PKCE for production
-                        .build())
-                .tokenSettings(TokenSettings.builder()
-                        .accessTokenTimeToLive(Duration.ofMinutes(30))
-                        .refreshTokenTimeToLive(Duration.ofDays(7))
                         .reuseRefreshTokens(false)
-                        .build())
-                .build();
-        */
+                        .build());
 
-        return new InMemoryRegisteredClientRepository(testClient);
+        if (extraRedirectUri != null && !extraRedirectUri.isBlank()) {
+            builder.redirectUri(extraRedirectUri);
+        }
+
+        return new InMemoryRegisteredClientRepository(builder.build());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,16 @@ server.servlet.context-path=${SERVER_CONTEXT_PATH:/}
 server.error.include-stacktrace=${SERVER_ERROR_INCLUDE_STACKTRACE:never}
 server.error.include-message=${SERVER_ERROR_INCLUDE_MESSAGE:always}
 
+# JWT key persistence (path without extension; .private.pem and .public.pem will be appended)
+jwt.key-path=${JWT_KEY_PATH:keys/jwt}
+
+# OAuth2 client credentials (override in production)
+oauth2.client.secret=${OAUTH2_CLIENT_SECRET:secret}
+oauth2.extra-redirect-uri=${OAUTH2_EXTRA_REDIRECT_URI:}
+
+# CORS — comma-separated list of additional allowed origin patterns (e.g. https://*.example.com)
+cors.allowed-origins=${CORS_ALLOWED_ORIGINS:}
+
 # Application Information
 spring.application.name=OAuth2 Authorization Server
 info.app.name=${spring.application.name}


### PR DESCRIPTION
## Summary
- RSA key pair is now loaded from / saved to disk (`JWT_KEY_PATH`) so tokens survive server restarts
- PKCE requirement enabled (`requireProofKey=true`) on the test client
- Client secret read from `OAUTH2_CLIENT_SECRET` env var instead of hardcoded
- Postman redirect URI moved to `OAUTH2_EXTRA_REDIRECT_URI` env var; removed from code
- CORS allowed origins driven by `CORS_ALLOWED_ORIGINS` env var; removed `yourdomain.com` placeholder

## Fixes
Issues #1, #2, #3, #4, #6 from the production checklist.

## Test plan
- [ ] Server starts and generates `keys/jwt.private.pem` + `keys/jwt.public.pem` on first run
- [ ] Server restart reuses existing keys; existing JWTs remain valid
- [ ] Client credentials flow works with `OAUTH2_CLIENT_SECRET` env var set
- [ ] Authorization code flow requires PKCE (`code_challenge` param)
- [ ] Postman redirect URI injected via `OAUTH2_EXTRA_REDIRECT_URI` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)