### PR TITLE
fix(persistence): replace in-memory stores with JDBC-backed repositories

### DIFF
--- a/src/main/java/com/example/config/AuthorizationServerConfig.java
+++ b/src/main/java/com/example/config/AuthorizationServerConfig.java
@@ -8,8 +8,14 @@ import com.nimbusds.jose.proc.SecurityContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
 import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer;
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
@@ -57,6 +63,18 @@ public class AuthorizationServerConfig {
     }
 
     @Bean
+    public OAuth2AuthorizationService authorizationService(JdbcOperations jdbcOperations,
+                                                            RegisteredClientRepository registeredClientRepository) {
+        return new JdbcOAuth2AuthorizationService(jdbcOperations, registeredClientRepository);
+    }
+
+    @Bean
+    public OAuth2AuthorizationConsentService authorizationConsentService(JdbcOperations jdbcOperations,
+                                                                          RegisteredClientRepository registeredClientRepository) {
+        return new JdbcOAuth2AuthorizationConsentService(jdbcOperations, registeredClientRepository);
+    }
+
+    @Bean
     public JWKSource<SecurityContext> jwkSource() {
         KeyPair keyPair = loadOrGenerateRsaKey();
         RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
@@ -78,11 +96,9 @@ public class AuthorizationServerConfig {
     public OAuth2TokenCustomizer<JwtEncodingContext> jwtCustomizer() {
         return context -> {
             if (context.getTokenType().getValue().equals("access_token")) {
-                // Add custom claims to JWT
                 context.getClaims().claim("iss_custom", "OAuth2 Authorization Server");
                 context.getClaims().claim("server_version", "1.0.0");
 
-                // Add user authorities/roles to JWT if available
                 if (context.getPrincipal() != null && context.getPrincipal().getAuthorities() != null) {
                     context.getClaims().claim("authorities",
                         context.getPrincipal().getAuthorities().stream()
@@ -90,7 +106,6 @@ public class AuthorizationServerConfig {
                             .toList());
                 }
 
-                // Add client information
                 if (context.getRegisteredClient() != null) {
                     context.getClaims().claim("client_name", context.getRegisteredClient().getClientId());
                 }

--- a/src/main/java/com/example/config/DefaultSecurityConfig.java
+++ b/src/main/java/com/example/config/DefaultSecurityConfig.java
@@ -6,15 +6,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -80,19 +80,24 @@ public class DefaultSecurityConfig {
     }
 
     @Bean
-    public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
-        UserDetails user = User.builder()
-                .username("user")
-                .password(passwordEncoder.encode("password"))
-                .roles("USER")
-                .build();
+    public UserDetailsService userDetailsService(DataSource dataSource, PasswordEncoder passwordEncoder) {
+        JdbcUserDetailsManager manager = new JdbcUserDetailsManager(dataSource);
 
-        UserDetails admin = User.builder()
-                .username("admin")
-                .password(passwordEncoder.encode("admin"))
-                .roles("USER", "ADMIN")
-                .build();
+        if (!manager.userExists("user")) {
+            manager.createUser(User.builder()
+                    .username("user")
+                    .password(passwordEncoder.encode("password"))
+                    .roles("USER")
+                    .build());
+        }
+        if (!manager.userExists("admin")) {
+            manager.createUser(User.builder()
+                    .username("admin")
+                    .password(passwordEncoder.encode("admin"))
+                    .roles("USER", "ADMIN")
+                    .build());
+        }
 
-        return new InMemoryUserDetailsManager(user, admin);
+        return manager;
     }
 }

--- a/src/main/java/com/example/config/DefaultSecurityConfig.java
+++ b/src/main/java/com/example/config/DefaultSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -80,24 +81,29 @@ public class DefaultSecurityConfig {
     }
 
     @Bean
-    public UserDetailsService userDetailsService(DataSource dataSource, PasswordEncoder passwordEncoder) {
-        JdbcUserDetailsManager manager = new JdbcUserDetailsManager(dataSource);
+    public UserDetailsService userDetailsService(DataSource dataSource) {
+        return new JdbcUserDetailsManager(dataSource);
+    }
 
-        if (!manager.userExists("user")) {
-            manager.createUser(User.builder()
-                    .username("user")
-                    .password(passwordEncoder.encode("password"))
-                    .roles("USER")
-                    .build());
-        }
-        if (!manager.userExists("admin")) {
-            manager.createUser(User.builder()
-                    .username("admin")
-                    .password(passwordEncoder.encode("admin"))
-                    .roles("USER", "ADMIN")
-                    .build());
-        }
-
-        return manager;
+    // Seeding runs via ApplicationRunner — after spring.sql.init schemas are applied
+    @Bean
+    public ApplicationRunner seedUsers(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
+        return args -> {
+            JdbcUserDetailsManager manager = (JdbcUserDetailsManager) userDetailsService;
+            if (!manager.userExists("user")) {
+                manager.createUser(User.builder()
+                        .username("user")
+                        .password(passwordEncoder.encode("password"))
+                        .roles("USER")
+                        .build());
+            }
+            if (!manager.userExists("admin")) {
+                manager.createUser(User.builder()
+                        .username("admin")
+                        .password(passwordEncoder.encode("admin"))
+                        .roles("USER", "ADMIN")
+                        .build());
+            }
+        };
     }
 }

--- a/src/main/java/com/example/config/RegisteredClientConfig.java
+++ b/src/main/java/com/example/config/RegisteredClientConfig.java
@@ -3,11 +3,12 @@ package com.example.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.OidcScopes;
-import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
@@ -26,35 +27,43 @@ public class RegisteredClientConfig {
     private String extraRedirectUri;
 
     @Bean
-    public RegisteredClientRepository registeredClientRepository(PasswordEncoder passwordEncoder) {
-        RegisteredClient.Builder builder = RegisteredClient.withId(UUID.randomUUID().toString())
-                .clientId("test-client")
-                .clientSecret(passwordEncoder.encode(clientSecret))
-                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
-                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-                .redirectUri("http://localhost:9000/login/oauth2/code/test-client")
-                .redirectUri("http://localhost:9000/authorized")
-                .scope(OidcScopes.OPENID)
-                .scope(OidcScopes.PROFILE)
-                .scope("read")
-                .scope("write")
-                .clientSettings(ClientSettings.builder()
-                        .requireAuthorizationConsent(true)
-                        .requireProofKey(true)
-                        .build())
-                .tokenSettings(TokenSettings.builder()
-                        .accessTokenTimeToLive(Duration.ofHours(1))
-                        .refreshTokenTimeToLive(Duration.ofDays(30))
-                        .reuseRefreshTokens(false)
-                        .build());
+    public RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations,
+                                                                  PasswordEncoder passwordEncoder) {
+        JdbcRegisteredClientRepository repository = new JdbcRegisteredClientRepository(jdbcOperations);
 
-        if (extraRedirectUri != null && !extraRedirectUri.isBlank()) {
-            builder.redirectUri(extraRedirectUri);
+        // Seed the test client only if it doesn't already exist
+        if (repository.findByClientId("test-client") == null) {
+            RegisteredClient.Builder builder = RegisteredClient.withId(UUID.randomUUID().toString())
+                    .clientId("test-client")
+                    .clientSecret(passwordEncoder.encode(clientSecret))
+                    .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                    .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                    .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                    .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                    .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                    .redirectUri("http://localhost:9000/login/oauth2/code/test-client")
+                    .redirectUri("http://localhost:9000/authorized")
+                    .scope(OidcScopes.OPENID)
+                    .scope(OidcScopes.PROFILE)
+                    .scope("read")
+                    .scope("write")
+                    .clientSettings(ClientSettings.builder()
+                            .requireAuthorizationConsent(true)
+                            .requireProofKey(true)
+                            .build())
+                    .tokenSettings(TokenSettings.builder()
+                            .accessTokenTimeToLive(Duration.ofHours(1))
+                            .refreshTokenTimeToLive(Duration.ofDays(30))
+                            .reuseRefreshTokens(false)
+                            .build());
+
+            if (extraRedirectUri != null && !extraRedirectUri.isBlank()) {
+                builder.redirectUri(extraRedirectUri);
+            }
+
+            repository.save(builder.build());
         }
 
-        return new InMemoryRegisteredClientRepository(builder.build());
+        return repository;
     }
 }

--- a/src/main/java/com/example/config/RegisteredClientConfig.java
+++ b/src/main/java/com/example/config/RegisteredClientConfig.java
@@ -1,6 +1,7 @@
 package com.example.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -27,43 +28,47 @@ public class RegisteredClientConfig {
     private String extraRedirectUri;
 
     @Bean
-    public RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations,
-                                                                  PasswordEncoder passwordEncoder) {
-        JdbcRegisteredClientRepository repository = new JdbcRegisteredClientRepository(jdbcOperations);
+    public RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
+        return new JdbcRegisteredClientRepository(jdbcOperations);
+    }
 
-        // Seed the test client only if it doesn't already exist
-        if (repository.findByClientId("test-client") == null) {
-            RegisteredClient.Builder builder = RegisteredClient.withId(UUID.randomUUID().toString())
-                    .clientId("test-client")
-                    .clientSecret(passwordEncoder.encode(clientSecret))
-                    .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
-                    .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
-                    .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                    .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-                    .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-                    .redirectUri("http://localhost:9000/login/oauth2/code/test-client")
-                    .redirectUri("http://localhost:9000/authorized")
-                    .scope(OidcScopes.OPENID)
-                    .scope(OidcScopes.PROFILE)
-                    .scope("read")
-                    .scope("write")
-                    .clientSettings(ClientSettings.builder()
-                            .requireAuthorizationConsent(true)
-                            .requireProofKey(true)
-                            .build())
-                    .tokenSettings(TokenSettings.builder()
-                            .accessTokenTimeToLive(Duration.ofHours(1))
-                            .refreshTokenTimeToLive(Duration.ofDays(30))
-                            .reuseRefreshTokens(false)
-                            .build());
+    // Seeding runs via ApplicationRunner — after spring.sql.init schemas are applied
+    @Bean
+    public ApplicationRunner seedClients(RegisteredClientRepository registeredClientRepository,
+                                          PasswordEncoder passwordEncoder) {
+        return args -> {
+            JdbcRegisteredClientRepository repository = (JdbcRegisteredClientRepository) registeredClientRepository;
+            if (repository.findByClientId("test-client") == null) {
+                RegisteredClient.Builder builder = RegisteredClient.withId(UUID.randomUUID().toString())
+                        .clientId("test-client")
+                        .clientSecret(passwordEncoder.encode(clientSecret))
+                        .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                        .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                        .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                        .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                        .redirectUri("http://localhost:9000/login/oauth2/code/test-client")
+                        .redirectUri("http://localhost:9000/authorized")
+                        .scope(OidcScopes.OPENID)
+                        .scope(OidcScopes.PROFILE)
+                        .scope("read")
+                        .scope("write")
+                        .clientSettings(ClientSettings.builder()
+                                .requireAuthorizationConsent(true)
+                                .requireProofKey(true)
+                                .build())
+                        .tokenSettings(TokenSettings.builder()
+                                .accessTokenTimeToLive(Duration.ofHours(1))
+                                .refreshTokenTimeToLive(Duration.ofDays(30))
+                                .reuseRefreshTokens(false)
+                                .build());
 
-            if (extraRedirectUri != null && !extraRedirectUri.isBlank()) {
-                builder.redirectUri(extraRedirectUri);
+                if (extraRedirectUri != null && !extraRedirectUri.isBlank()) {
+                    builder.redirectUri(extraRedirectUri);
+                }
+
+                repository.save(builder.build());
             }
-
-            repository.save(builder.build());
-        }
-
-        return repository;
+        };
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,6 +42,15 @@ spring.h2.console.settings.web-allow-others=${H2_CONSOLE_WEB_ALLOW_OTHERS:false}
 # JPA/Hibernate Configuration
 # =============================================================================
 
+# Initialize Spring Security JDBC schemas before Hibernate processes entities
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=\
+  classpath:org/springframework/security/core/userdetails/jdbc/users.ddl,\
+  classpath:org/springframework/security/oauth2/server/authorization/client/oauth2-registered-client-schema.sql,\
+  classpath:org/springframework/security/oauth2/server/authorization/oauth2-authorization-schema.sql,\
+  classpath:org/springframework/security/oauth2/server/authorization/oauth2-authorization-consent-schema.sql
+
 spring.jpa.show-sql=${JPA_SHOW_SQL:false}
 spring.jpa.hibernate.ddl-auto=${JPA_DDL_AUTO:create-drop}
 spring.jpa.database-platform=${JPA_DATABASE_PLATFORM:org.hibernate.dialect.H2Dialect}


### PR DESCRIPTION
## Summary
- Replaces `InMemoryRegisteredClientRepository` with `JdbcRegisteredClientRepository`
- Replaces implicit in-memory token store with `JdbcOAuth2AuthorizationService` and `JdbcOAuth2AuthorizationConsentService`
- Replaces `InMemoryUserDetailsManager` with `JdbcUserDetailsManager`
- Configures `spring.sql.init` to load all required Spring Security JDBC schemas on startup
- Seeds test data only when records don't already exist (idempotent startup)

## Fixes
Issues #7, #8, #9 from the production checklist.

## Test plan
- [ ] Server starts and initialises all 4 JDBC schemas against H2
- [ ] Client credentials flow works after restart (client persisted in DB)
- [ ] Authorization code flow works after restart (token persisted in DB)
- [ ] User login works after restart (users persisted in DB)
- [ ] Re-starting the server does not duplicate test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)