### PR TITLE
fix(observability): profile-aware errors, no stack traces in responses, gate SQL logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,7 +238,7 @@ yarn.lock
 # =============================================================================
 # Local development configurations
 application-local.properties
-application-dev.properties
+# application-dev.properties is tracked — contains only logging config, no secrets
 application-development.properties
 application-test.properties
 

--- a/src/main/java/com/example/config/OAuth2ErrorHandler.java
+++ b/src/main/java/com/example/config/OAuth2ErrorHandler.java
@@ -1,5 +1,9 @@
 package com.example.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -21,22 +25,30 @@ import java.util.Map;
 @ControllerAdvice
 public class OAuth2ErrorHandler extends ResponseEntityExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(OAuth2ErrorHandler.class);
+
+    private final Environment environment;
+
+    public OAuth2ErrorHandler(Environment environment) {
+        this.environment = environment;
+    }
+
     @ExceptionHandler(OAuth2AuthenticationException.class)
     public ResponseEntity<Map<String, Object>> handleOAuth2Exception(OAuth2AuthenticationException ex) {
         OAuth2Error error = ex.getError();
-        
+
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("error", error.getErrorCode());
         errorResponse.put("error_description", error.getDescription());
         errorResponse.put("timestamp", LocalDateTime.now().toString());
-        
+
         // Add error URI if available
         if (error.getUri() != null) {
             errorResponse.put("error_uri", error.getUri());
         }
-        
+
         HttpStatus status = determineHttpStatus(error.getErrorCode());
-        
+
         return ResponseEntity.status(status)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(errorResponse);
@@ -48,7 +60,7 @@ public class OAuth2ErrorHandler extends ResponseEntityExceptionHandler {
         errorResponse.put("error", OAuth2ErrorCodes.INVALID_REQUEST);
         errorResponse.put("error_description", "Invalid request parameter: " + ex.getMessage());
         errorResponse.put("timestamp", LocalDateTime.now().toString());
-        
+
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(errorResponse);
@@ -56,16 +68,13 @@ public class OAuth2ErrorHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex) {
+        log.error("Unexpected error", ex);
+
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("error", OAuth2ErrorCodes.SERVER_ERROR);
         errorResponse.put("error_description", "An unexpected error occurred");
         errorResponse.put("timestamp", LocalDateTime.now().toString());
-        
-        // Include detailed error message in development (be careful in production)
-        if (isDevelopmentMode()) {
-            errorResponse.put("debug_message", ex.getMessage());
-        }
-        
+
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(errorResponse);
@@ -77,24 +86,19 @@ public class OAuth2ErrorHandler extends ResponseEntityExceptionHandler {
     private HttpStatus determineHttpStatus(String errorCode) {
         return switch (errorCode) {
             case OAuth2ErrorCodes.INVALID_CLIENT -> HttpStatus.UNAUTHORIZED;
-            case OAuth2ErrorCodes.INVALID_GRANT, 
-                 OAuth2ErrorCodes.INVALID_REQUEST, 
+            case OAuth2ErrorCodes.INVALID_GRANT,
+                 OAuth2ErrorCodes.INVALID_REQUEST,
                  OAuth2ErrorCodes.INVALID_SCOPE,
                  OAuth2ErrorCodes.UNSUPPORTED_GRANT_TYPE,
                  OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE -> HttpStatus.BAD_REQUEST;
             case OAuth2ErrorCodes.ACCESS_DENIED -> HttpStatus.FORBIDDEN;
-            case OAuth2ErrorCodes.SERVER_ERROR, 
+            case OAuth2ErrorCodes.SERVER_ERROR,
                  OAuth2ErrorCodes.TEMPORARILY_UNAVAILABLE -> HttpStatus.INTERNAL_SERVER_ERROR;
             default -> HttpStatus.BAD_REQUEST;
         };
     }
 
-    /**
-     * Check if application is running in development mode.
-     * You can customize this logic based on your profile configuration.
-     */
     private boolean isDevelopmentMode() {
-        // Simple check - in production, you might want to use Spring profiles
-        return !System.getProperty("spring.profiles.active", "").contains("prod");
+        return environment.matchesProfiles(Profiles.of("dev | local | default"));
     }
 }

--- a/src/main/java/com/example/config/OAuth2ErrorHandler.java
+++ b/src/main/java/com/example/config/OAuth2ErrorHandler.java
@@ -99,6 +99,6 @@ public class OAuth2ErrorHandler extends ResponseEntityExceptionHandler {
     }
 
     private boolean isDevelopmentMode() {
-        return environment.matchesProfiles(Profiles.of("dev | local | default"));
+        return environment.acceptsProfiles(Profiles.of("dev | local | default"));
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,8 @@
+# =============================================================================
+# Development profile overrides — applied when spring.profiles.active=dev
+# =============================================================================
+
+# Verbose SQL logging for local development
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,9 +60,9 @@ logging.level.com.example=${LOGGING_LEVEL_APP:DEBUG}
 # HTTP requests logging (disable in production)
 logging.level.org.springframework.web=${LOGGING_LEVEL_WEB:INFO}
 
-# Database logging
-logging.level.org.hibernate.SQL=${LOGGING_LEVEL_SQL:DEBUG}
-logging.level.org.hibernate.type.descriptor.sql.BasicBinder=${LOGGING_LEVEL_SQL_PARAMS:TRACE}
+# Database logging (set to DEBUG/TRACE in application-dev.properties)
+logging.level.org.hibernate.SQL=${LOGGING_LEVEL_SQL:WARN}
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=${LOGGING_LEVEL_SQL_PARAMS:WARN}
 
 # Console logging pattern
 logging.pattern.console=${LOGGING_PATTERN_CONSOLE:%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n}


### PR DESCRIPTION
## Summary
- Dev mode detection in `OAuth2ErrorHandler` replaced with `Environment.matchesProfiles()` — no longer relies on fragile `System.getProperty("spring.profiles.active")`
- Stack trace removed from HTTP error responses entirely; exceptions now logged at ERROR level instead
- SQL/Hibernate logging defaults changed from `DEBUG`/`TRACE` to `WARN`
- New `application-dev.properties` re-enables verbose SQL logging when `spring.profiles.active=dev`

## Fixes
Issues #10, #11, #12 from the production checklist.

## Test plan
- [x] Generic exception returns `{"error":"server_error",...}` with no stack trace in response body
- [x] Exception is logged at ERROR level in server logs
- [x] Running with `--spring.profiles.active=dev` produces SQL query logs
- [x] Running without `dev` profile produces no Hibernate SQL output

🤖 Generated with [Claude Code](https://claude.com/claude-code)