### PR TITLE
fix(ci): JDK 21, Spring Boot 3.3.6, spring-security-test, context load test

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,12 +25,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
+    - name: Verify Java version
+      run: java -version
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     
     <properties>
         <java.version>21</java.version>
-        <spring-boot.version>3.1.0</spring-boot.version>
-        <oauth2-authorization-server.version>1.1.2</oauth2-authorization-server.version>
+        <spring-boot.version>3.3.6</spring-boot.version>
+        <oauth2-authorization-server.version>1.3.3</oauth2-authorization-server.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -68,6 +68,11 @@
             <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -89,8 +94,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
+            <version>6.3.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/example/AuthorizationServerApplicationTests.java
+++ b/src/test/java/com/example/AuthorizationServerApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AuthorizationServerApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- CI workflow upgraded from JDK 17 to JDK 21 to match `pom.xml` `java.version`
- Added `java -version` verification step to catch future mismatches early
- Spring Boot upgraded from `3.1.0` (EOL) to `3.3.6`
- `spring-security-oauth2-authorization-server` upgraded from `1.1.2` to `1.3.3`
- `maven-compiler-plugin` source/target corrected from `17` to `21`
- Added `spring-security-test` dependency
- Added `AuthorizationServerApplicationTests` with a Spring context load test

## Fixes
Issues #13, #14, #15 from the production checklist.

## Test plan
- [x] CI pipeline passes with JDK 21
- [x] `mvn test` runs and `contextLoads` test passes
- [x] No compilation errors with Java 21 target

🤖 Generated with [Claude Code](https://claude.com/claude-code)