### PR TITLE
fix(hardening): security headers, rate limiting on /oauth2/token, env-var issuer URI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Rate limiting -->
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>8.10.1</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/config/DefaultSecurityConfig.java
+++ b/src/main/java/com/example/config/DefaultSecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -29,6 +31,12 @@ public class DefaultSecurityConfig {
     @Value("${cors.allowed-origins:}")
     private String corsAllowedOrigins;
 
+    private final RateLimitingFilter rateLimitingFilter;
+
+    public DefaultSecurityConfig(RateLimitingFilter rateLimitingFilter) {
+        this.rateLimitingFilter = rateLimitingFilter;
+    }
+
     @Bean
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -42,9 +50,18 @@ public class DefaultSecurityConfig {
             )
             .formLogin(withDefaults())
             .headers(headers -> headers
-                    .frameOptions(frameOptions -> frameOptions.sameOrigin()) // For H2 console
+                .frameOptions(frameOptions -> frameOptions.sameOrigin()) // For H2 console
+                .httpStrictTransportSecurity(hsts -> hsts
+                    .includeSubDomains(true)
+                    .maxAgeInSeconds(31536000))
+                .contentTypeOptions(withDefaults())
+                .referrerPolicy(referrer -> referrer
+                    .policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+                .contentSecurityPolicy(csp -> csp
+                    .policyDirectives("default-src 'self'; frame-ancestors 'self'"))
             )
-            .csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**")); // For H2 console
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**"))
+            .addFilterBefore(rateLimitingFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/config/ProviderConfig.java
+++ b/src/main/java/com/example/config/ProviderConfig.java
@@ -1,15 +1,20 @@
 package com.example.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 
 @Configuration
 public class ProviderConfig {
+
+    @Value("${oauth2.issuer-uri:http://localhost:9000}")
+    private String issuerUri;
+
     @Bean
     public AuthorizationServerSettings authorizationServerSettings() {
         return AuthorizationServerSettings.builder()
-                .issuer("http://localhost:9000")
+                .issuer(issuerUri)
                 .build();
     }
 }

--- a/src/main/java/com/example/config/RateLimitingFilter.java
+++ b/src/main/java/com/example/config/RateLimitingFilter.java
@@ -1,0 +1,52 @@
+package com.example.config;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class RateLimitingFilter extends OncePerRequestFilter {
+
+    private final ConcurrentHashMap<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !"POST".equalsIgnoreCase(request.getMethod())
+                || !"/oauth2/token".equals(request.getServletPath());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String clientIp = request.getRemoteAddr();
+        Bucket bucket = buckets.computeIfAbsent(clientIp, ip -> newBucket());
+
+        if (bucket.tryConsume(1)) {
+            filterChain.doFilter(request, response);
+        } else {
+            response.setStatus(429);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.getWriter().write(
+                    "{\"error\":\"too_many_requests\",\"error_description\":\"Rate limit exceeded\"}"
+            );
+        }
+    }
+
+    private Bucket newBucket() {
+        // 20 requests per minute per IP
+        Bandwidth limit = Bandwidth.classic(20, Refill.greedy(20, Duration.ofMinutes(1)));
+        return Bucket.builder().addLimit(limit).build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,7 @@ jwt.key-path=${JWT_KEY_PATH:keys/jwt}
 # OAuth2 client credentials (override in production)
 oauth2.client.secret=${OAUTH2_CLIENT_SECRET:secret}
 oauth2.extra-redirect-uri=${OAUTH2_EXTRA_REDIRECT_URI:}
+oauth2.issuer-uri=${OAUTH2_ISSUER_URI:http://localhost:9000}
 
 # CORS — comma-separated list of additional allowed origin patterns (e.g. https://*.example.com)
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS:}


### PR DESCRIPTION
## Summary
- Security response headers added: HSTS (1yr, includeSubDomains), Content-Security-Policy, Referrer-Policy, X-Content-Type-Options
- `RateLimitingFilter` added using Bucket4j: 20 requests/min per IP on `POST /oauth2/token`; responds with HTTP 429 and RFC 6749-compliant JSON on exhaustion
- `ProviderConfig` now reads issuer URI from `OAUTH2_ISSUER_URI` env var (was hardcoded to `http://localhost:9000`)
- `oauth2.issuer-uri` property added to `application.properties`
- `bucket4j-core 8.10.1` added to `pom.xml`

## Fixes
Issues #16, #17, #18 from the production checklist.

## Test plan
- [ ] Response headers include `Strict-Transport-Security`, `Content-Security-Policy`, `Referrer-Policy`, `X-Content-Type-Options`
- [ ] More than 20 rapid `POST /oauth2/token` requests from same IP returns HTTP 429
- [ ] 429 body is `{"error":"too_many_requests","error_description":"Rate limit exceeded"}`
- [ ] Setting `OAUTH2_ISSUER_URI=https://auth.example.com` reflects in `/.well-known/oauth-authorization-server` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)